### PR TITLE
Combine empty rect to path for every tutorialHoles in web environment

### DIFF
--- a/lib/src/widgets/overlay_tutorial_scope.dart
+++ b/lib/src/widgets/overlay_tutorial_scope.dart
@@ -271,6 +271,14 @@ class _RenderOverlayTutorialBackbone extends RenderProxyBox {
     _calculateEntryRects();
 
     overlayTutorialHoles.entries.forEach((entry) {
+      if (kIsWeb) {
+        path = Path.combine(
+          PathOperation.difference,
+          path,
+          Path()..addRect(Rect.zero),
+        );
+      }
+
       final overlayTutorialHoleContext = entry.value;
       final rect = _entryRects[overlayTutorialHoleContext];
       if (rect == null) return;

--- a/lib/src/widgets/overlay_tutorial_scope.dart
+++ b/lib/src/widgets/overlay_tutorial_scope.dart
@@ -273,7 +273,7 @@ class _RenderOverlayTutorialBackbone extends RenderProxyBox {
     overlayTutorialHoles.entries.forEach((entry) {
       // Temporary add empty rect to path to overcome
       // the issue: https://github.com/TabooSun/overlay_tutorial/issues/15.
-      // Kindly remove if there is any better solution or flutter web fixed the render issue.
+      // Kindly remove if there is any better solution or Flutter fixes it.
 
       if (kIsWeb) {
         path = Path.combine(

--- a/lib/src/widgets/overlay_tutorial_scope.dart
+++ b/lib/src/widgets/overlay_tutorial_scope.dart
@@ -271,6 +271,10 @@ class _RenderOverlayTutorialBackbone extends RenderProxyBox {
     _calculateEntryRects();
 
     overlayTutorialHoles.entries.forEach((entry) {
+      // Temporary add empty rect to path to overcome
+      // the issue: https://github.com/TabooSun/overlay_tutorial/issues/15.
+      // Kindly remove if there is any better solution or flutter web fixed the render issue.
+
       if (kIsWeb) {
         path = Path.combine(
           PathOperation.difference,


### PR DESCRIPTION
Currently, overlay_tutorial 2.0.0 in flutter web could not render correctly. Below image is tested by example project of overlay_tutorial 2.0.0 :
<img width="400" alt="Screenshot 2021-05-03 at 1 10 07 PM" src="https://user-images.githubusercontent.com/57253441/116842995-1879f780-ac11-11eb-9c6e-bc7d56f50b10.png">

After testing around, came out with a temporary solution to overcome the issue that combines empty Rect to the path for every tutorialHoles in the web environment. And it will work as usual :
<img width="403" alt="Screenshot 2021-05-03 at 1 10 26 PM" src="https://user-images.githubusercontent.com/57253441/116843072-5d059300-ac11-11eb-9cc3-62a14a33154f.png">

